### PR TITLE
StoreDeleted behavior

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     *site-packages*
     *tests*
     *.tox*
+    *__init__.py*
 show_missing = True
 exclude_lines =
     raise NotImplementedError

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# Virtualenv folder
+.env/

--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,9 @@ htmlcov
 .project
 .pydevproject
 
-# Pycharm/Intellij
+# Pycharm/Intellij/VSCode
 .idea
+.vscode/
 
 # Complexity
 output/*.html

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "${workspaceFolder}/.env/bin/python"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "${workspaceFolder}/.env/bin/python"
+}

--- a/behaviors/behaviors.py
+++ b/behaviors/behaviors.py
@@ -8,7 +8,7 @@ from slugify import slugify
 
 from .querysets import (AuthoredQuerySet, EditoredQuerySet,
                         PublishedQuerySet, ReleasedQuerySet,
-                        DeletedQuerySet)
+                        StoreDeletedQuerySet)
 
 
 class Authored(models.Model):
@@ -158,13 +158,14 @@ class Timestamped(models.Model):
         return super(Timestamped, self).save(*args, **kwargs)
 
 
-class Deleted(models.Model):
+class StoreDeleted(models.Model):
     """
-    An abstract behavior representing deleted a model with``deleted`` field.
+    An abstract behavior representing storedeleted a model with``deleted`` field,
+    avoiding the model object to be deleted.
     """
     deleted = models.DateTimeField(null=True, blank=True)
 
-    objects = DeletedQuerySet.as_manager()
+    objects = StoreDeletedQuerySet.as_manager()
 
     class Meta:
         abstract = True
@@ -172,4 +173,4 @@ class Deleted(models.Model):
     def delete(self, *args, **kwargs):
         if self.pk:
             self.deleted = timezone.now()
-        return super(Deleted, self).save(*args, **kwargs)
+        return super(StoreDeleted, self).save(*args, **kwargs)

--- a/behaviors/behaviors.py
+++ b/behaviors/behaviors.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
+from django.core.exceptions import ObjectDoesNotExist
 
 from slugify import slugify
 
@@ -170,12 +171,18 @@ class StoreDeleted(models.Model):
     class Meta:
         abstract = True
 
+    @property
+    def is_deleted(self):
+        return self.deleted != None
+
     def delete(self, *args, **kwargs):
-        if self.pk:
-            self.deleted = timezone.now()
+        if not self.pk:
+            raise ObjectDoesNotExist('Object must be created before it can be deleted')
+        self.deleted = timezone.now()
         return super(StoreDeleted, self).save(*args, **kwargs)
 
     def restore(self, *args, **kwargs):
-        if self.pk:
-            self.deleted = None
+        if not self.pk:
+            raise ObjectDoesNotExist('Object must be created before it can be restored')
+        self.deleted = None
         return super(StoreDeleted, self).save(*args, **kwargs)

--- a/behaviors/behaviors.py
+++ b/behaviors/behaviors.py
@@ -7,7 +7,8 @@ from django.utils import timezone
 from slugify import slugify
 
 from .querysets import (AuthoredQuerySet, EditoredQuerySet,
-                        PublishedQuerySet, ReleasedQuerySet)
+                        PublishedQuerySet, ReleasedQuerySet,
+                        DeletedQuerySet)
 
 
 class Authored(models.Model):
@@ -155,3 +156,20 @@ class Timestamped(models.Model):
         if self.pk:
             self.modified = timezone.now()
         return super(Timestamped, self).save(*args, **kwargs)
+
+
+class Deleted(models.Model):
+    """
+    An abstract behavior representing deleted a model with``deleted`` field.
+    """
+    deleted = models.DateTimeField(null=True, blank=True)
+
+    objects = DeletedQuerySet.as_manager()
+
+    class Meta:
+        abstract = True
+
+    def delete(self, *args, **kwargs):
+        if self.pk:
+            self.deleted = timezone.now()
+        return super(Deleted, self).save(*args, **kwargs)

--- a/behaviors/behaviors.py
+++ b/behaviors/behaviors.py
@@ -161,7 +161,7 @@ class Timestamped(models.Model):
 class StoreDeleted(models.Model):
     """
     An abstract behavior representing storedeleted a model with``deleted`` field,
-    avoiding the model object to be deleted.
+    avoiding the model object to be deleted and restored.
     """
     deleted = models.DateTimeField(null=True, blank=True)
 
@@ -173,4 +173,9 @@ class StoreDeleted(models.Model):
     def delete(self, *args, **kwargs):
         if self.pk:
             self.deleted = timezone.now()
+        return super(StoreDeleted, self).save(*args, **kwargs)
+
+    def restore(self, *args, **kwargs):
+        if self.pk:
+            self.deleted = None
         return super(StoreDeleted, self).save(*args, **kwargs)

--- a/behaviors/behaviors.py
+++ b/behaviors/behaviors.py
@@ -160,8 +160,8 @@ class Timestamped(models.Model):
 
 class StoreDeleted(models.Model):
     """
-    An abstract behavior representing storedeleted a model with``deleted`` field,
-    avoiding the model object to be deleted and restored.
+    An abstract behavior representing store deleted a model with``deleted`` field,
+    avoiding the model object to be deleted and allowing you to restore it.
     """
     deleted = models.DateTimeField(null=True, blank=True)
 

--- a/behaviors/managers.py
+++ b/behaviors/managers.py
@@ -3,7 +3,8 @@ from __future__ import unicode_literals
 from django.db import models
 
 from .querysets import (AuthoredQuerySet, EditoredQuerySet,
-                        PublishedQuerySet, ReleasedQuerySet)
+                        PublishedQuerySet, ReleasedQuerySet,
+                        DeletedQuerySet)
 
 
 class AuthoredManager(models.Manager):
@@ -49,3 +50,20 @@ class ReleasedManager(models.Manager):
 
     def no_release_date(self):
         return self.get_queryset().no_release_date()
+
+class DeletedManager(models.Manager):
+
+    def _get_base_queryset(self):
+        return DeletedQuerySet(self.model, using=self._db)
+
+    def get_queryset(self):
+        return self._get_base_queryset().get_queryset()
+
+    def deleted(self):
+        return self._get_base_queryset().deleted()
+
+    def undeleted(self):
+        return self._get_base_queryset().undeleted()
+
+    def allow_deleted(self):
+        return self._get_base_queryset().allow_deleted()

--- a/behaviors/managers.py
+++ b/behaviors/managers.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from .querysets import (AuthoredQuerySet, EditoredQuerySet,
                         PublishedQuerySet, ReleasedQuerySet,
-                        DeletedQuerySet)
+                        StoreDeletedQuerySet)
 
 
 class AuthoredManager(models.Manager):
@@ -51,10 +51,10 @@ class ReleasedManager(models.Manager):
     def no_release_date(self):
         return self.get_queryset().no_release_date()
 
-class DeletedManager(models.Manager):
+class StoreDeletedManager(models.Manager):
 
     def _get_base_queryset(self):
-        return DeletedQuerySet(self.model, using=self._db)
+        return StoreDeletedQuerySet(self.model, using=self._db)
 
     def get_queryset(self):
         return self._get_base_queryset().get_queryset()
@@ -62,8 +62,8 @@ class DeletedManager(models.Manager):
     def deleted(self):
         return self._get_base_queryset().deleted()
 
-    def undeleted(self):
-        return self._get_base_queryset().undeleted()
+    def not_deleted(self):
+        return self._get_base_queryset().not_deleted()
 
     def allow_deleted(self):
         return self._get_base_queryset().allow_deleted()

--- a/behaviors/querysets.py
+++ b/behaviors/querysets.py
@@ -38,16 +38,16 @@ class ReleasedQuerySet(models.QuerySet):
     def no_release_date(self):
         return self.filter(models.Q(release_date=None))
 
-class DeletedQuerySet(models.QuerySet):
+class StoreDeletedQuerySet(models.QuerySet):
 
     def get_queryset(self):
-        return self.undeleted()
+        return self.not_deleted()
 
     def deleted(self):
-        return self.filter(models.Q(deleted=None))
-
-    def undeleted(self):
         return self.exclude(deleted__isnull=True)
+
+    def not_deleted(self):
+        return self.exclude(deleted__isnull=False)
     
     def allow_deleted(self):
         return self

--- a/behaviors/querysets.py
+++ b/behaviors/querysets.py
@@ -37,3 +37,17 @@ class ReleasedQuerySet(models.QuerySet):
 
     def no_release_date(self):
         return self.filter(models.Q(release_date=None))
+
+class DeletedQuerySet(models.QuerySet):
+
+    def get_queryset(self):
+        return self.undeleted()
+
+    def deleted(self):
+        return self.filter(models.Q(deleted=None))
+
+    def undeleted(self):
+        return self.exclude(deleted__isnull=True)
+    
+    def allow_deleted(self):
+        return self

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,9 +1,9 @@
 from django.db import models
 
 from behaviors.behaviors import (Authored, Editored, Published, Released,
-                                 Slugged, Timestamped)
+                                 Slugged, Timestamped, StoreDeleted)
 from behaviors.managers import (AuthoredManager, EditoredManager,
-                                PublishedManager, ReleasedManager)
+                                PublishedManager, ReleasedManager, StoreDeletedManager)
 from behaviors.querysets import PublishedQuerySet
 
 
@@ -95,3 +95,6 @@ class MixinQuerySet(PublishedQuerySet, models.QuerySet):
 
 class MixinObjectsQuerySet(Published):
     objects = MixinQuerySet.as_manager()
+
+class StoreDeletedMock(StoreDeleted):
+    objects = StoreDeletedManager()

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -178,11 +178,17 @@ class TestStoreDeleted(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.mock_to_deleted = StoreDeletedMock.objects.create()
+        cls.mock_to_delete = StoreDeletedMock.objects.create()
+        cls.mock_to_restore = StoreDeletedMock.objects.create()
 
     def setUp(self):
-        self.mock_to_deleted.refresh_from_db()
+        self.mock_to_delete.refresh_from_db()
 
     def test_delete_model(self):
-        self.mock_to_deleted.delete()
-        self.assertIsNotNone(self.mock_to_deleted.deleted)
+        self.mock_to_delete.delete()
+        self.assertIsNotNone(self.mock_to_delete.deleted)
+
+    def test_restore_model(self):
+        self.mock_to_restore.delete()
+        self.mock_to_restore.restore()
+        self.assertIsNone(self.mock_to_restore.deleted)

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -9,6 +9,7 @@ Tests for `django-behaviors` behaviors module.
 """
 from django.contrib.auth import get_user_model
 from django.utils import timezone
+from django.core.exceptions import ObjectDoesNotExist
 
 from test_plus.test import TestCase
 
@@ -192,3 +193,31 @@ class TestStoreDeleted(TestCase):
         self.mock_to_restore.delete()
         self.mock_to_restore.restore()
         self.assertIsNone(self.mock_to_restore.deleted)
+
+    def test_delete_not_created_object_raises_exception(self):
+        mock = StoreDeletedMock()
+        self.assertIsNone(mock.pk)
+        with self.assertRaises(ObjectDoesNotExist) as raises_context:
+            mock.delete()
+            self.assertIsNotNone(raises_context)
+        
+    def test_restore_not_created_object_raises_exception(self):
+        mock = StoreDeletedMock()
+        self.assertIsNone(mock.pk)
+        with self.assertRaises(ObjectDoesNotExist) as raises_context:
+            mock.restore()
+            self.assertIsNotNone(raises_context)
+
+    def test_is_deleted_property_returns_true_when_delete_object(self):
+        self.mock_to_delete.delete()
+        self.assertTrue(self.mock_to_delete.is_deleted)
+
+    def test_is_deleted_property_returns_false_when_restore_object(self):
+        self.mock_to_restore.delete()
+        self.mock_to_restore.restore()
+        self.assertFalse(self.mock_to_restore.is_deleted)
+
+    def test_is_deleted_property_returns_false_when_create_object(self):
+        mock = StoreDeletedMock()
+        mock.save()
+        self.assertFalse(mock.is_deleted)

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -15,7 +15,8 @@ from test_plus.test import TestCase
 from datetime import timedelta
 
 from .models import (AuthoredMock, EditoredMock, PublishedMock,
-                     ReleasedMock, SluggedMock, TimestampedMock)
+                     ReleasedMock, SluggedMock, TimestampedMock,
+                     StoreDeletedMock)
 
 
 class TestAuthored(TestCase):
@@ -172,3 +173,16 @@ class TestTimestamped(TestCase):
     def test_timestamp_changed_after_save(self):
         self.mock.save()
         self.assertTrue(self.mock.changed)
+
+class TestStoreDeleted(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.mock_to_deleted = StoreDeletedMock.objects.create()
+
+    def setUp(self):
+        self.mock_to_deleted.refresh_from_db()
+
+    def test_delete_model(self):
+        self.mock_to_deleted.delete()
+        self.assertIsNotNone(self.mock_to_deleted.deleted)

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -14,7 +14,7 @@ from test_plus.test import TestCase
 
 from datetime import timedelta
 
-from .models import AuthoredMock, EditoredMock, PublishedMock, ReleasedMock
+from .models import AuthoredMock, EditoredMock, PublishedMock, ReleasedMock, StoreDeletedMock
 
 
 class TestAuthoredQuerySet(TestCase):
@@ -208,3 +208,42 @@ class TestReleasedQuerySet(TestCase):
         self.assertEqual(queryset.count(), 1)
         for record in queryset:
             self.assertIsNone(record.release_date)
+
+
+class TestStoreDeletedQuerySet(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        for i in range(0, 10):
+            if i % 2 == 0:
+                StoreDeletedMock.objects.create()
+            else:
+                StoreDeletedMock.objects.create().delete()
+
+    def test_object_all_returns_only_not_deleted_models(self):
+        queryset = StoreDeletedMock.objects.all()
+        self.assertIsNotNone(queryset)
+        self.assertTrue(queryset.count(), 5)
+        for record in queryset:
+            self.assertIsNone(record.deleted)
+    
+    def test_deleted_returns_only_deleted_models(self):
+        queryset = StoreDeletedMock.objects.deleted()
+        self.assertIsNotNone(queryset)
+        self.assertTrue(queryset.count(), 5)
+        for record in queryset:
+            self.assertIsNotNone(record.deleted)
+            self.assertEqual(record.deleted.date(), timezone.now().date())
+
+    def test_not_deleted_returns_only_not_deleted_models(self):
+        queryset = StoreDeletedMock.objects.not_deleted()
+        self.assertIsNotNone(queryset)
+        self.assertTrue(queryset.count(), 5)
+        for record in queryset:
+            self.assertIsNone(record.deleted)
+
+    def test_allow_deleted_returns_all_models(self):
+        queryset = StoreDeletedMock.objects.not_deleted()
+        self.assertIsNotNone(queryset)
+        self.assertTrue(queryset.count(), 10)
+            

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -223,14 +223,14 @@ class TestStoreDeletedQuerySet(TestCase):
     def test_object_all_returns_only_not_deleted_models(self):
         queryset = StoreDeletedMock.objects.all()
         self.assertIsNotNone(queryset)
-        self.assertTrue(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
         for record in queryset:
             self.assertIsNone(record.deleted)
     
     def test_deleted_returns_only_deleted_models(self):
         queryset = StoreDeletedMock.objects.deleted()
         self.assertIsNotNone(queryset)
-        self.assertTrue(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
         for record in queryset:
             self.assertIsNotNone(record.deleted)
             self.assertEqual(record.deleted.date(), timezone.now().date())
@@ -238,12 +238,12 @@ class TestStoreDeletedQuerySet(TestCase):
     def test_not_deleted_returns_only_not_deleted_models(self):
         queryset = StoreDeletedMock.objects.not_deleted()
         self.assertIsNotNone(queryset)
-        self.assertTrue(queryset.count(), 5)
+        self.assertEqual(queryset.count(), 5)
         for record in queryset:
             self.assertIsNone(record.deleted)
 
     def test_allow_deleted_returns_all_models(self):
-        queryset = StoreDeletedMock.objects.not_deleted()
+        queryset = StoreDeletedMock.objects.allow_deleted()
         self.assertIsNotNone(queryset)
-        self.assertTrue(queryset.count(), 10)
+        self.assertEqual(queryset.count(), 10)
             

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -7,5 +7,5 @@ from . import views
 
 
 urlpatterns = [
-    url(r'/authored$', views.AuthoredMockCreateView.as_view(), name='authored'),
+    url(r'authored$', views.AuthoredMockCreateView.as_view(), name='authored'),
 ]


### PR DESCRIPTION
**StoreDeleted** behavior brings idea to avoid the record to be deleted from database. The behavior controls the state of model object by using `deleted` field. Basic rule is:

- If `deleted` field `is None`, this indicate the model is enable to use.
- If `deleted` field `is not None`, indicated the model was deleted.

Besides, the method `restore()` allow to give the model object back to `objects` results.

The default `get_queryset()` from model was changed to only search through records that have `deleted == None`, but queryset methods like `not_deleted()` and `allow_deleted()` give the possibility to list the deleted models.