### PR TITLE
make awesome-slugify an optional requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Features
 - **Editored** to add an ``editor`` to your models
 - **Published** to add a ``publication_status`` (draft or published) to your models
 - **Released** to add a ``release_date`` to your models
-- **Slugged** to add a ``slug`` to your models (thanks @apirobot) (enusre you have `awesome-slugify` installed, see above)
+- **Slugged** to add a ``slug`` to your models (thanks @apirobot) (ensure you have `awesome-slugify` installed, see above)
 - Easily compose together multiple ``behaviors`` to get desired functionality (e.g. ``Authored`` and ``Editored``)
 - Custom ``QuerySet`` methods added as managers to your models to utilize the added fields
 - Easily compose together multiple ``queryset`` or ``manager`` to get desired functionality

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ Quickstart
 Install Django Behaviors::
 
     pip install django-behaviors
+    # Or, if you are going to use the Slugged behaviour
+    pip install django-behaviors[slugged]
 
 Add it to your `INSTALLED_APPS`:
 
@@ -48,7 +50,7 @@ Features
 - **Editored** to add an ``editor`` to your models
 - **Published** to add a ``publication_status`` (draft or published) to your models
 - **Released** to add a ``release_date`` to your models
-- **Slugged** to add a ``slug`` to your models (thanks @apirobot)
+- **Slugged** to add a ``slug`` to your models (thanks @apirobot) (enusre you have `awesome-slugify` installed, see above)
 - Easily compose together multiple ``behaviors`` to get desired functionality (e.g. ``Authored`` and ``Editored``)
 - Custom ``QuerySet`` methods added as managers to your models to utilize the added fields
 - Easily compose together multiple ``queryset`` or ``manager`` to get desired functionality

--- a/behaviors/behaviors.py
+++ b/behaviors/behaviors.py
@@ -5,7 +5,10 @@ from django.db import models
 from django.utils import timezone
 from django.core.exceptions import ObjectDoesNotExist
 
-from slugify import slugify
+try:
+    from slugify import slugify
+except ImportError:
+    from django.utils.text import slugify
 
 from .querysets import (AuthoredQuerySet, EditoredQuerySet,
                         PublishedQuerySet, ReleasedQuerySet,
@@ -120,7 +123,11 @@ class Slugged(models.Model):
         super(Slugged, self).save(*args, **kwargs)
 
     def get_slug(self):
-        return slugify(getattr(self, "slug_source"), to_lower=True)
+        try:
+            return slugify(getattr(self, "slug_source"), to_lower=True)
+        except TypeError:
+            # django.utils.text.slugify fallback
+            return slugify(getattr(self, "slug_source"))
 
     def is_unique_slug(self, slug):
         qs = self.__class__.objects.filter(slug=slug)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,3 @@
--r requirements.txt
-
 coverage==4.3.4
 mock>=1.0.1
 flake8>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(
         'behaviors',
     ],
     include_package_data=True,
-    install_requires=[
-        "awesome-slugify>=1.6.5",
-    ],
+    extras={
+        "slugged": "awesome-slugify>=1.6.5",
+    },
     license="MIT",
     zip_safe=False,
     keywords='django-behaviors',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-django-18
-    {py27,py34,py35,py36}-django-111
-    {py34,py35,py36}-django-20
+    {py27,py34,py35,py36}-django-18-{slugify,noslugify}
+    {py27,py34,py35,py36}-django-111-{slugify,noslugify}
+    {py34,py35,py36}-django-20-{slugify,noslugify}
 
 [testenv]
 setenv =
@@ -12,6 +12,7 @@ deps =
     django-18: Django>=1.8,<1.9
     django-111: Django>=1.11,<2.0
     django-20: Django>=2.0,<2.1
+    slugify: -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt
 basepython =
     py36: python3.6


### PR DESCRIPTION
fixes #5.

By default, `awesome-slugify` will not be installed, unless you run `pip install django-behaviors[slugged]`.

If `awesome-slugify` is not present, we fall back to `django.utils.text.slugify`.