### PR TITLE
Added option to allow non-unique slugs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -722,17 +722,21 @@ The ``Slugged`` behavior allows you to easily add a ``slug`` field to your model
 
     class Slugged(models.Model):
         """
-        An abstract behavior representing adding a unique slug to a model
-        based on the slug_source property.
+        An abstract behavior representing adding a slug (by default, unique) to
+        a model based on the slug_source property.
         """
-        slug = models.SlugField(max_length=255, unique=True, blank=True)
+        slug = models.SlugField(
+            max_length=255,
+            unique=BehaviorsConfig.are_slug_unique(),
+            blank=True)
 
         class Meta:
             abstract = True
 
         def save(self, *args, **kwargs):
             if not self.slug:
-                self.slug = self.generate_unique_slug()
+                self.slug = self.generate_unique_slug() \
+                    if BehaviorsConfig.are_slug_unique() else self.get_slug()
             super(Slugged, self).save(*args, **kwargs)
 
         def get_slug(self):
@@ -753,9 +757,14 @@ The ``Slugged`` behavior allows you to easily add a ``slug`` field to your model
 
             return new_slug
 
-The ``slug`` uses the awesome-slugify package which will preserve unicode character slugs. The ``slug`` must be unique and is guaranteed to be unique by the class appending a number ``-[0-9+]`` to the end of the slug if it is not unique. The ``unique`` field type `adds an index`_ to the ``slug`` field.
+The ``slug`` uses the awesome-slugify package which will preserve unicode
+character slugs. By default, the ``slug`` must be unique and is guaranteed to
+be unique by the class appending a number ``-[0-9+]`` to the end of the slug
+if it is not unique. The ``unique`` field type `adds an index`_ to the ``slug`` field.
 
 Add the ``slug_source`` property to your class when mixing in the behavior.
+
+To allow non-unique slugs, add ``UNIQUE_SLUG_BEHAVIOR = False`` to your project's settings.
 
 .. code-block:: python
 
@@ -784,7 +793,8 @@ Add the ``slug_source`` property to your class when mixing in the behavior.
     >>> m.get_absolute_url()
     '/myapp/prepended-text-for-fun-aj/detail'
 
-Your ``slug_source`` attribute can be a mix of any of the model data available at the time of save, generally it is some ``name`` type of field. You could also hash the primary key and/or some other data as a ``slug_source``. The ``slug`` is unique so it can be used to define the ``get_absolute_url()`` method on your model.
+Your ``slug_source`` attribute can be a mix of any of the model data available at the time of save, generally it is some ``name`` type of field. You could also hash the primary key and/or some other data as a ``slug_source``.
+By default, the ``slug`` is unique so it can be used to define the ``get_absolute_url()`` method on your model.
 
 Thanks to @apirobot for sending the PR for the ``Slugged`` behavior.
 

--- a/behaviors/apps.py
+++ b/behaviors/apps.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class BehaviorsConfig(AppConfig):
     name = 'behaviors'
+
+    @classmethod
+    def are_slug_unique(cls):
+        # By default, the Slugged behavior will generate unique slugs.
+        # You can disable this constraint in your project's settings module.
+        return getattr(settings, "UNIQUE_SLUG_BEHAVIOR", True)

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -86,6 +86,18 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
+            name='NonUniqueSluggedMock',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True,
+                                        serialize=False, verbose_name='ID')),
+                ('slug', models.SlugField(blank=True, max_length=255, unique=False)),
+                ('title', models.CharField(max_length=255)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
             name='StoreDeletedMock',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,7 +3,8 @@ from django.db import models
 from behaviors.behaviors import (Authored, Editored, Published, Released,
                                  Slugged, Timestamped, StoreDeleted)
 from behaviors.managers import (AuthoredManager, EditoredManager,
-                                PublishedManager, ReleasedManager, StoreDeletedManager)
+                                PublishedManager, ReleasedManager,
+                                StoreDeletedManager)
 from behaviors.querysets import PublishedQuerySet
 
 
@@ -20,6 +21,14 @@ class PublishedMock(Published):
 
 
 class SluggedMock(Slugged):
+    title = models.CharField(max_length=255)
+
+    @property
+    def slug_source(self):
+        return self.title
+
+
+class NonUniqueSluggedMock(Slugged):
     title = models.CharField(max_length=255)
 
     @property

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -33,3 +33,5 @@ if django.VERSION >= (1, 10):
     MIDDLEWARE = ()
 else:
     MIDDLEWARE_CLASSES = ()
+
+UNIQUE_SLUG_BEHAVIOR = True


### PR DESCRIPTION
Implements suggestion #13 
Allow non-unique slugs by adding ``UNIQUE_SLUG_BEHAVIOR = False`` to a project's settings.